### PR TITLE
fix variable fetching

### DIFF
--- a/src/eval.zig
+++ b/src/eval.zig
@@ -245,14 +245,17 @@ pub const Environment = struct {
     }
 
     pub fn fetch_variable(self: *Self, ident: []const u8) !?*model.Atom {
-        if (self.globals.getPtr(ident)) |val| {
-            return val;
-        }
-
-        for (self.stack.items) |frame| {
+        // TODO this stupid while loop requires 2 casts to deal with.
+        var i = @as(i65, self.stack.items.len-1);
+        while (i >= 0) : (i -= 1) {
+            var frame = self.stack.items[@intCast(i)];
             if (frame.locals.getPtr(ident)) |val| {
                 return val;
             }
+        }
+
+        if (self.globals.getPtr(ident)) |val| {
+            return val;
         }
 
         return null;

--- a/src/eval.zig
+++ b/src/eval.zig
@@ -262,6 +262,17 @@ pub const Environment = struct {
     }
 
     pub fn add_local(self: *Self, name: []const u8, val: model.Atom) !void {
+        // TODO same issue with `fetch_variable` about the things being casted.
+        var i = @as(i65, self.stack.items.len-1);
+
+        while(i >= 0) : (i -= 1) {
+            var frame = self.stack.items[@intCast(i)];
+            if(frame.locals.contains(name)) {
+                try frame.locals.put(name, val);
+                return;
+            }
+        }
+
         try self.current_stack_frame().locals.put(name, val);
     }
 


### PR DESCRIPTION
reorders fetch checks so innermost shadowed variable is the one that gets used